### PR TITLE
fix(cta): enclose in comment tags

### DIFF
--- a/add_debugger.js
+++ b/add_debugger.js
@@ -4,10 +4,9 @@ if (typeof initDebugger === 'undefined') {
         if (document.body.innerHTML.match(tenderlyRegex)) {
             return
         }
-
         const injectElement = document.createElement('div')
         injectElement.className = 'debuggerTest'
-        injectElement.innerHTML = 'View in Tenderly'
+        injectElement.innerHTML = '/* ↗️ View in Tenderly */'
 
         const regex = new RegExp('0x([a-f0-9]{64})')
         const htmlElementRegex = new RegExp('(?:</[^<]+>)|(?:<[^<]+/>)')
@@ -15,7 +14,7 @@ if (typeof initDebugger === 'undefined') {
         const text = document.querySelectorAll('h1, h2, h3, h4, h5, p, li, td, caption, span, a')
         for (let i = 0; i < text.length; i++) {
             if (!htmlElementRegex.test(text[i].innerHTML) && text[i].innerHTML.search(regex) === 0) {
-                text[i].innerHTML = text[i].innerHTML.replace(regex, '0x$1 <a href="https://dashboard.tenderly.co/tx/0x$1/one-click-debugger">View in Tenderly!</a>')
+                text[i].innerHTML = text[i].innerHTML.replace(regex, '0x$1 <a href="https://dashboard.tenderly.co/tx/0x$1/one-click-debugger">/* ↗️ View in Tenderly! */</a>')
             }
         }
     }


### PR DESCRIPTION
currently when this is viewed looking at source code it can be mistaken as part of the code. Make it unambiguously clear that this is injected by wrapping it in comments.

![](https://d.pr/i/EQdLfy.jpeg)